### PR TITLE
fix: dependency warning when installing in React 17 project

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "framer-motion": ">= 3",
-    "react": ">= ^16.8"
+    "react": ">= ^16.8 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.12",


### PR DESCRIPTION
```
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.2" from the root project
npm ERR! Could not resolve dependency:
npm ERR! peer react@">= ^16.8" from scroller-motion@1.1.0
npm ERR! node_modules/scroller-motion
npm ERR!   scroller-motion@"1.1.0" from the root project
npm ERR! 
```