### PR TITLE
fix: framer-motion peer dependency error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "node": ">= 12"
       },
       "peerDependencies": {
-        "framer-motion": "^6.5.0",
+        "framer-motion": "^6.5.0 || ^7.0",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debounce-fn": "^4.0.0"
   },
   "peerDependencies": {
-    "framer-motion": "^6.5.0",
+    "framer-motion": "^6.5.0 || ^7.0",
     "react": "^16.8 || ^17.0 || ^18.0",
     "react-dom": "^16.8 || ^17.0 || ^18.0"
   },


### PR DESCRIPTION
This should hopefully fix all these errors:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: scroller-motion@1.2.0
npm ERR! Found: framer-motion@7.6.1
npm ERR! node_modules/framer-motion
npm ERR!   framer-motion@"^7.6.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer framer-motion@"^6.5.0" from scroller-motion@1.2.0
npm ERR! node_modules/scroller-motion
npm ERR!   scroller-motion@"^1.2.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: framer-motion@6.5.1
npm ERR! node_modules/framer-motion
npm ERR!   peer framer-motion@"^6.5.0" from scroller-motion@1.2.0
npm ERR!   node_modules/scroller-motion
npm ERR!     scroller-motion@"^1.2.0" from the root project
```